### PR TITLE
Escaping HTML-sensitive characters in items description.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 coverage/*
 doc/*
 spec/pag_seguro/integration/config_example.yml
+.DS_Store

--- a/lib/pag_seguro/checkout.xml.haml
+++ b/lib/pag_seguro/checkout.xml.haml
@@ -17,7 +17,7 @@
     - items.each do |item|
       %item
         %id= item.id
-        %description= item.description
+        %description&= item.description
         %amount= item.amount
         %quantity= item.quantity
         - if item.shipping_cost.present?

--- a/lib/pag_seguro/version.rb
+++ b/lib/pag_seguro/version.rb
@@ -1,3 +1,3 @@
 module PagSeguro
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
When an item's name was composed with the '&' character, PagSeguro
returned a malformed XML error. In these cases, it is necessary to
escape the item's name.

Version bumped to 0.3.2.
