### PR TITLE
Adds Shipping Cost to the generated checkout XML

### DIFF
--- a/lib/pag_seguro/checkout.xml.haml
+++ b/lib/pag_seguro/checkout.xml.haml
@@ -43,6 +43,8 @@
         %type= shipping.type
       - else
         %type 3
+      - if shipping.cost.present?
+        %cost= shipping.cost
       %address
         %country BRA
         - if shipping.state.present?

--- a/spec/pag_seguro/checkout_xml_spec.rb
+++ b/spec/pag_seguro/checkout_xml_spec.rb
@@ -11,7 +11,7 @@ items = [
 sender_info = {name: "Stefano Diem Benatti", email: "stefano@heavenstudio.com.br", phone_ddd: "11", phone_number: "93430994"}
 
 shipping_info = {type: PagSeguro::Shipping::SEDEX, state: "SP", city: "São Paulo", postal_code: "05363000",
-  district: "Jd. PoliPoli", street: "Av. Otacilio Tomanik", number: "775", complement: "apto. 92"}
+  district: "Jd. PoliPoli", street: "Av. Otacilio Tomanik", number: "775", complement: "apto. 92", cost: "12.13" }
 
 
 describe PagSeguro::Payment do
@@ -117,6 +117,10 @@ describe PagSeguro::Payment do
       
       it "should allow to set a different shipping type" do
         @xml.css("checkout shipping type").first.content.to_i.should == PagSeguro::Shipping::SEDEX
+      end
+
+      it "should allow to set a shipping cost" do
+        @xml.css("checkout shipping cost").first.content.should == "12.13"
       end
 
       it "should have state" do

--- a/spec/pag_seguro/shipping_spec.rb
+++ b/spec/pag_seguro/shipping_spec.rb
@@ -9,7 +9,8 @@ valid_attributes = {
   district: "Jd. PoliPoli",
   street: "Av. Otacilio Tomanik",
   number: "775",
-  complement: "apto. 92"
+  complement: "apto. 92",
+  cost: "12.13"
 }
 
 describe PagSeguro::Shipping do
@@ -23,29 +24,36 @@ describe PagSeguro::Shipping do
     it { @shipping.should have_attribute_accessor(:street) }
     it { @shipping.should have_attribute_accessor(:number) }
     it { @shipping.should have_attribute_accessor(:complement) }
-    
+    it { @shipping.should have_attribute_accessor(:cost) }
+
     describe "types" do
       it "should be pac if type is 1" do
         @shipping.stub( :type ){ 1 }
         @shipping.should be_pac
       end
-      
+
       it "should be sedex if type is 2" do
         @shipping.stub( :type ){ 2 }
         @shipping.should be_sedex
       end
-      
+
       it "should be unidentified if type is 3" do
         @shipping.stub( :type ){ 3 }
         @shipping.should be_unidentified
       end
     end
   end
-  
+
+  describe "#cost" do
+    it "should return the same specified cost" do
+      PagSeguro::Shipping.new(valid_attributes).cost.should == "12.13"
+    end
+  end
+
   it "should be able to initialize all attributes" do
     PagSeguro::Shipping.new(valid_attributes).should be_valid
   end
-  
+
   it "should not show postal code unless valid" do
     PagSeguro::Shipping.new(valid_attributes).postal_code.should == "05363000"
     PagSeguro::Shipping.new(valid_attributes.merge(postal_code: 1234567)).postal_code.should be_blank


### PR DESCRIPTION
Before this change, it wasn't possible to define a global shipping cost.
PagSeguro allow us to define a global one so you don't have to define
one for each item in the cart.

This commit includes this change as well as its tests.

(Algum problema no commit ser em inglês?)
